### PR TITLE
Added fprintf, vfprintf, and enabled/disable color functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To use `cprintf`, define `CPRINTF_IMPLEMENTATION` before including the header fi
 #include "cprintf.h"
 ```
 
-Then, you can use `cprintf`, `cfprintf`, and `cvfprintf` in your code just like printf, but with additional formatting options.
+Then, you can use `cprintf`, `cfprintf`, `cvfprintf`, `csnprintf`, and `cvsnprintf` in your code just like printf, but with additional formatting options.
 
 Aditionally, you can enable/disable colored output with: `cprintf_enable`, `cprintf_disable`, `cprintf_toggle`, and `cprintf_get_status`. The default behavior is enabled, this can be overwritten by defining `CPRINTF_ENABLE_FLAG_DEFAULT` to either `0` (disabled) or `1` (enabled).
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To use `cprintf`, define `CPRINTF_IMPLEMENTATION` before including the header fi
 
 Then, you can use `cprintf`, `cfprintf`, and `cvfprintf` in your code just like printf, but with additional formatting options.
 
-Aditionally, you can enable/disable colored output with: `cprintf_enable`, `cprintf_disable`, and `cprintf_toggle`. The default behavior is enabled, this can be overwritten by defining `CPRINTF_ENABLE_FLAG_DEFAULT` to either `0` (disabled) or `1` (enabled).
+Aditionally, you can enable/disable colored output with: `cprintf_enable`, `cprintf_disable`, `cprintf_toggle`, and `cprintf_get_status`. The default behavior is enabled, this can be overwritten by defining `CPRINTF_ENABLE_FLAG_DEFAULT` to either `0` (disabled) or `1` (enabled).
 
 ```C
 #define CPRINTF_IMPLEMENTATION

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ To use `cprintf`, define `CPRINTF_IMPLEMENTATION` before including the header fi
 
 Then, you can use cprintf in your code just like printf, but with additional formatting options.
 
+Aditionally, you can enable/disable colored output with: `cprintf_enable`, `cprintf_disable`, and `cprintf_toggle`. The default behavior is enabled, this can be overwritten by defining `CPRINTF_ENABLE_FLAG_DEFAULT` to either `0` (disabled) or `1` (enabled).
+
+```C
+#define CPRINTF_IMPLEMENTATION
+#define CPRINTF_ENABLE_FLAG_DEFAULT 0
+#include "cprintf.h"
+```
+
 ---
 
 ## EXAMPLE
@@ -39,6 +47,12 @@ Then, you can use cprintf in your code just like printf, but with additional for
 #include "cprintf.h"
 
 int main(int argc, char * argv[]) {
+    cprintf("%FbBLUE TEXT%Ar\n");
+
+    cprintf_disable();
+    cprintf("%FbNORMAL TEXT%Ar\n");
+
+    cprintf_enable();
     cprintf("%FbBLUE TEXT%Ar\n");
     return 0;
 }

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To use `cprintf`, define `CPRINTF_IMPLEMENTATION` before including the header fi
 #include "cprintf.h"
 ```
 
-Then, you can use cprintf in your code just like printf, but with additional formatting options.
+Then, you can use `cprintf`, `cfprintf`, and `cvfprintf` in your code just like printf, but with additional formatting options.
 
 Aditionally, you can enable/disable colored output with: `cprintf_enable`, `cprintf_disable`, and `cprintf_toggle`. The default behavior is enabled, this can be overwritten by defining `CPRINTF_ENABLE_FLAG_DEFAULT` to either `0` (disabled) or `1` (enabled).
 
@@ -53,7 +53,7 @@ int main(int argc, char * argv[]) {
     cprintf("%FbNORMAL TEXT%Ar\n");
 
     cprintf_enable();
-    cprintf("%FbBLUE TEXT%Ar\n");
+    cfprintf(stderr, "%FbBLUE TEXT%Ar\n");
     return 0;
 }
 ```

--- a/cprintf.h
+++ b/cprintf.h
@@ -82,9 +82,7 @@ void cprintf_toggle(void) {
   cprintf_enable_flag ^= 1;
 }
 
-int cprintf(const char * restrict format, ...) {
-  va_list args;
-  va_start(args, format);
+int cvfprintf(FILE *stream, const char * restrict format, va_list args) {
   char buffer[CPRINTF_BUFFER_SIZE];
   int index = 0;
   const char * pointer = format;
@@ -148,8 +146,30 @@ int cprintf(const char * restrict format, ...) {
   }
 
   buffer[index] = '\0';
-  vprintf(buffer, args);
+  return vfprintf(stream, buffer, args);
+}
+
+
+int cfprintf(FILE *stream, const char * restrict format, ...) {
+  int rc;
+  va_list args;
+  va_start(args, format);
+
+  rc = cvfprintf(stream, format, args);
+
   va_end(args);
+  return rc;
+}
+
+int cprintf(const char * restrict format, ...) {
+  int rc;
+  va_list args;
+  va_start(args, format);
+
+  rc = cvfprintf(stdout, format, args);
+
+  va_end(args);
+  return rc;
 }
 
 #endif // CPRINTF_IMPLEMENTATION

--- a/cprintf.h
+++ b/cprintf.h
@@ -65,6 +65,23 @@ static const char * CPRINTF_ATTRIBUTES[] = {
 #include <stdarg.h>
 #include <string.h>
 
+#ifndef CPRINTF_ENABLE_FLAG_DEFAULT
+#define CPRINTF_ENABLE_FLAG_DEFAULT 1
+#endif
+static int cprintf_enable_flag = CPRINTF_ENABLE_FLAG_DEFAULT;
+
+void cprintf_enable(void) {
+  cprintf_enable_flag = 1; 
+}
+
+void cprintf_disable(void) {
+  cprintf_enable_flag = 0; 
+}
+
+void cprintf_toggle(void) {
+  cprintf_enable_flag ^= 1;
+}
+
 int cprintf(const char * restrict format, ...) {
   va_list args;
   va_start(args, format);
@@ -82,14 +99,14 @@ int cprintf(const char * restrict format, ...) {
           pointer++;
 
           switch (pointer[0]) {
-            case 'k': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (pointer[-1] == 'F') ? CPRINTF_FG_COLOURS[CPRINTF_BLACK]   : CPRINTF_BG_COLOURS[CPRINTF_BLACK]);    break;
-            case 'r': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (pointer[-1] == 'F') ? CPRINTF_FG_COLOURS[CPRINTF_RED]     : CPRINTF_BG_COLOURS[CPRINTF_RED]);      break;
-            case 'g': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (pointer[-1] == 'F') ? CPRINTF_FG_COLOURS[CPRINTF_GREEN]   : CPRINTF_BG_COLOURS[CPRINTF_GREEN]);    break;
-            case 'y': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (pointer[-1] == 'F') ? CPRINTF_FG_COLOURS[CPRINTF_YELLOW]  : CPRINTF_BG_COLOURS[CPRINTF_YELLOW]);   break;
-            case 'b': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (pointer[-1] == 'F') ? CPRINTF_FG_COLOURS[CPRINTF_BLUE]    : CPRINTF_BG_COLOURS[CPRINTF_BLUE]);     break;
-            case 'm': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (pointer[-1] == 'F') ? CPRINTF_FG_COLOURS[CPRINTF_MAGENTA] : CPRINTF_BG_COLOURS[CPRINTF_MAGENTA]);  break;
-            case 'c': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (pointer[-1] == 'F') ? CPRINTF_FG_COLOURS[CPRINTF_CYAN]    : CPRINTF_BG_COLOURS[CPRINTF_CYAN]);     break;
-            case 'w': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (pointer[-1] == 'F') ? CPRINTF_FG_COLOURS[CPRINTF_WHITE]   : CPRINTF_BG_COLOURS[CPRINTF_WHITE]);    break;
+            case 'k': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (!cprintf_enable_flag) ? "" : (pointer[-1] == 'F') ? CPRINTF_FG_COLOURS[CPRINTF_BLACK]   : CPRINTF_BG_COLOURS[CPRINTF_BLACK]);    break;
+            case 'r': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (!cprintf_enable_flag) ? "" : (pointer[-1] == 'F') ? CPRINTF_FG_COLOURS[CPRINTF_RED]     : CPRINTF_BG_COLOURS[CPRINTF_RED]);      break;
+            case 'g': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (!cprintf_enable_flag) ? "" : (pointer[-1] == 'F') ? CPRINTF_FG_COLOURS[CPRINTF_GREEN]   : CPRINTF_BG_COLOURS[CPRINTF_GREEN]);    break;
+            case 'y': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (!cprintf_enable_flag) ? "" : (pointer[-1] == 'F') ? CPRINTF_FG_COLOURS[CPRINTF_YELLOW]  : CPRINTF_BG_COLOURS[CPRINTF_YELLOW]);   break;
+            case 'b': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (!cprintf_enable_flag) ? "" : (pointer[-1] == 'F') ? CPRINTF_FG_COLOURS[CPRINTF_BLUE]    : CPRINTF_BG_COLOURS[CPRINTF_BLUE]);     break;
+            case 'm': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (!cprintf_enable_flag) ? "" : (pointer[-1] == 'F') ? CPRINTF_FG_COLOURS[CPRINTF_MAGENTA] : CPRINTF_BG_COLOURS[CPRINTF_MAGENTA]);  break;
+            case 'c': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (!cprintf_enable_flag) ? "" : (pointer[-1] == 'F') ? CPRINTF_FG_COLOURS[CPRINTF_CYAN]    : CPRINTF_BG_COLOURS[CPRINTF_CYAN]);     break;
+            case 'w': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (!cprintf_enable_flag) ? "" : (pointer[-1] == 'F') ? CPRINTF_FG_COLOURS[CPRINTF_WHITE]   : CPRINTF_BG_COLOURS[CPRINTF_WHITE]);    break;
           }
 
           index += strlen(&buffer[index]);
@@ -98,16 +115,16 @@ int cprintf(const char * restrict format, ...) {
             pointer++;
 
             switch (pointer[0]) {
-              case 'r': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", CPRINTF_ATTRIBUTES[CPRINTF_RESET]); break;
-              case 'b': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", CPRINTF_ATTRIBUTES[CPRINTF_BOLD]); break;
-              case 'f': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", CPRINTF_ATTRIBUTES[CPRINTF_DIM]); break;
-              case 'i': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", CPRINTF_ATTRIBUTES[CPRINTF_ITALIC]); break;
-              case 'u': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", CPRINTF_ATTRIBUTES[CPRINTF_UNDERLINE]); break;
-              case 'l': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", CPRINTF_ATTRIBUTES[CPRINTF_BLINK_SLOW]); break;
-              case 'k': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", CPRINTF_ATTRIBUTES[CPRINTF_BLINK_RAPID]); break;
-              case 'v': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", CPRINTF_ATTRIBUTES[CPRINTF_INVERTED]); break;
-              case 'h': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", CPRINTF_ATTRIBUTES[CPRINTF_HIDDEN]); break;
-              case 's': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", CPRINTF_ATTRIBUTES[CPRINTF_STRIKETHOUGH]); break;
+              case 'r': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (!cprintf_enable_flag) ? "" : CPRINTF_ATTRIBUTES[CPRINTF_RESET]); break;
+              case 'b': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (!cprintf_enable_flag) ? "" : CPRINTF_ATTRIBUTES[CPRINTF_BOLD]); break;
+              case 'f': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (!cprintf_enable_flag) ? "" : CPRINTF_ATTRIBUTES[CPRINTF_DIM]); break;
+              case 'i': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (!cprintf_enable_flag) ? "" : CPRINTF_ATTRIBUTES[CPRINTF_ITALIC]); break;
+              case 'u': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (!cprintf_enable_flag) ? "" : CPRINTF_ATTRIBUTES[CPRINTF_UNDERLINE]); break;
+              case 'l': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (!cprintf_enable_flag) ? "" : CPRINTF_ATTRIBUTES[CPRINTF_BLINK_SLOW]); break;
+              case 'k': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (!cprintf_enable_flag) ? "" : CPRINTF_ATTRIBUTES[CPRINTF_BLINK_RAPID]); break;
+              case 'v': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (!cprintf_enable_flag) ? "" : CPRINTF_ATTRIBUTES[CPRINTF_INVERTED]); break;
+              case 'h': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (!cprintf_enable_flag) ? "" : CPRINTF_ATTRIBUTES[CPRINTF_HIDDEN]); break;
+              case 's': snprintf(&buffer[index], CPRINTF_BUFFER_SIZE - index, "%s", (!cprintf_enable_flag) ? "" : CPRINTF_ATTRIBUTES[CPRINTF_STRIKETHOUGH]); break;
             }
 
             index += strlen(&buffer[index]);

--- a/cprintf.h
+++ b/cprintf.h
@@ -165,8 +165,11 @@ int cprintf_cfmt_snprintf (char *buf, size_t buf_n, const char * restrict format
     pointer++;
   }
 
+  index++;
   if (buf_iter != NULL) {
     *buf_iter = '\0';
+    buf_iter++;
+    remaining_n--;
   }
   return index;
 }

--- a/cprintf.h
+++ b/cprintf.h
@@ -82,6 +82,10 @@ void cprintf_toggle(void) {
   cprintf_enable_flag ^= 1;
 }
 
+int cprintf_get_status(void) {
+  return cprintf_enable_flag;
+}
+
 int cvfprintf(FILE *stream, const char * restrict format, va_list args) {
   char buffer[CPRINTF_BUFFER_SIZE];
   int index = 0;


### PR DESCRIPTION
Added enable/disable functionality for colored printing via:
- `cprintf_enable()`
- `cprintf_disable()`
- `cprintf_toggle()`
- `cprintf_get_status()`
- `CPRINTF_ENABLE_FLAG_DEFAULT`

Added support for alternate output streams with:
- `cfprintf()`
- `cvfprintf()`

Added support for buffer outputs with:
- `csnprintf()`
- `cvsnprintf()`

note: if not specified by the user, `CPRINTF_ENABLE_FLAG_DEFAULT` has value of 1, enabled. This is to maintain compatibility with earlier versions.